### PR TITLE
Update links in the CICS TS plugin docs

### DIFF
--- a/docs/UCD/CICS/component_templates.md
+++ b/docs/UCD/CICS/component_templates.md
@@ -25,7 +25,7 @@ You can bind your component to a specific version of the template to avoid autom
 
 ### More information
 
-For more information about creating, using, and editing component templates, see the [Component Templates](https://www.ibm.com/support/knowledgecenter/SS4GSP_7.1.1/com.ibm.udeploy.doc/topics/comp_template.html "Component Templates") section of the UrbanCode Deploy documentation or watch the introductory video, [Component Templates in IBM UrbanCode Deploy v6.0](https://mediacenter.ibm.com/media/Component+Templates+in+IBM+UrbanCode+Deploy+v6.0/0_m7rucqyz "Component Templates in IBM UrbanCode Deploy v6.0").
+For more information about creating, using, and editing component templates, see the [Component Templates](https://www.ibm.com/docs/en/devops-deploy/8.1.0?topic=components-component-templates "Component Templates") section of the UrbanCode Deploy documentation or watch the introductory video, [Component Templates in IBM UrbanCode Deploy v6.0](https://mediacenter.ibm.com/media/Component+Templates+in+IBM+UrbanCode+Deploy+v6.0/0_m7rucqyz "Component Templates in IBM UrbanCode Deploy v6.0").
 
 ### CICS TS template
 

--- a/docs/UCD/CICS/overview.md
+++ b/docs/UCD/CICS/overview.md
@@ -36,7 +36,7 @@ The CICS TS plug-in is supported to run against any of the following CICS editio
 
 Additionally, you must also have configured a CICS management client interface (CMCI) port, as described in topic [Setting up access for CICS Explorer](https://www.ibm.com/docs/en/cics-ts/6.x?topic=configuring-setting-up-cmci) in the IBM Knowledge Center.
 
-This plug-in requires UrbanCode Deploy 6.2.5 or later, and the [zOS Utility](https://urbancode.github.io/IBM-UCx-PLUGIN-DOCS/UCD/zos-deploy/) 10 plug-in or later. Using this plug-in requires the UrbanCode Deploy agent to be running with Java 8; for details of how to upgrade the version of Java used by the agent, see [Changing or updating the JRE of agents](https://www.ibm.com/support/knowledgecenter/SS4GSP_6.2.4/com.ibm.udeploy.doc/topics/jre_change_agent.html).
+This plug-in requires UrbanCode Deploy 6.2.5 or later, and the [zOS Utility](https://urbancode.github.io/IBM-UCx-PLUGIN-DOCS/UCD/zos-deploy/) 10 plug-in or later. Using this plug-in requires the UrbanCode Deploy agent to be running with Java 8; for details of how to upgrade the version of Java used by the agent, see [Changing or updating the JRE of agents](https://www.ibm.com/docs/en/devops-deploy/8.1.0?topic=configuration-changing-updating-jre-servers).
 
 ## Installation
 

--- a/docs/UCD/CICS/steps.md
+++ b/docs/UCD/CICS/steps.md
@@ -313,7 +313,7 @@ Undeploy CICS bundles. Requires CICS TS V5.1 or V5.2 with APAR PI56706, or V5.3 
 
 ### Overview of output properties
 
-A step in UrbanCode Deploy is able to return output properties. These can be used in the step post-processing script and to pass information between steps. For an example workflow using output properties, see [Properties](http://www.ibm.com/support/knowledgecenter/SS4GSP_7.2.0/com.ibm.udeploy.doc/topics/ud_properties_overview.html "Properties") in the UrbanCode Deploy documentation.
+A step in UrbanCode Deploy is able to return output properties. These can be used in the step post-processing script and to pass information between steps. For an example workflow using output properties, see [Properties](https://www.ibm.com/docs/en/devops-deploy/8.1.0?topic=deployment-properties "Properties") in the UrbanCode Deploy documentation.
 
 ### The cics.response.errors output property
 
@@ -350,7 +350,7 @@ The following is a sample of the cics.response.errors output when NEWCOPY fails 
 
 ### Use cics.response.errors in a post-processing script
 
-You can configure a post-processing script to run after a step finishes. Post-processing scripts can be used to ensure that the expected results occurred, and to pass properties between steps. For more information on using and storing reusable post-processing scripts, see the [Post-processing scripts](https://www.ibm.com/docs/en/urbancode-deploy/7.2.3?topic=processes-component#intro_component_processes) section of the Urban Code Deploy documentation.
+You can configure a post-processing script to run after a step finishes. Post-processing scripts can be used to ensure that the expected results occurred, and to pass properties between steps. For more information on using and storing reusable post-processing scripts, see the [Post-processing scripts](https://www.ibm.com/docs/en/devops-deploy/8.1.0?topic=processes-component) section of the Urban Code Deploy documentation.
 
 The following is a usage example of a post-processing script for the *New copy resources* step in the CICS TS plug-in:
 

--- a/docs/UCD/CICS/troubleshooting.md
+++ b/docs/UCD/CICS/troubleshooting.md
@@ -6,7 +6,6 @@ For more questions and answers, see the [UrbanCode forum](https://community.ibm.
 ### Troubleshooting sections
 
 - [CICS TS - Troubleshooting](#cics-ts---troubleshooting)
-    - [Troubleshooting sections](#troubleshooting-sections)
     - [FAQ](#faq)
     - [Using the step logs](#using-the-step-logs)
     - [Resources which operate asynchronously](#resources-which-operate-asynchronously)

--- a/docs/UCD/CICS/usage.md
+++ b/docs/UCD/CICS/usage.md
@@ -8,7 +8,7 @@
 
 Before you begin, ensure the following:
 
-* Ensure your UCD agent is installed. For more information on installing UCD agents, see [Installing agents from the command line](http://www.ibm.com/support/knowledgecenter/SS4GSP_7.2.0/com.ibm.udeploy.install.doc/topics/agentInstall.html?).
+* Ensure your UCD agent is installed. For more information on installing UCD agents, see [Installing agents from the command line](https://www.ibm.com/docs/en/devops-deploy/8.1.0?topic=agents-installing-from-command-line).
 * Ensure that the CICS region or CICSplex you want to connect to is available through the CICS Management Client Interface (CMCI).
 
 #### About this task
@@ -32,7 +32,7 @@ For CICS steps, it may be useful to set up a resource tree as previously describ
 | ```cics.username``` | Sysplex                           |
 | ```cics.password``` | Sysplex                           |
 
-For more general information on property inheritance, see [Referring to properties](https://www.ibm.com/docs/en/urbancode-deploy/7.2.3?topic=deployment-properties).
+For more general information on property inheritance, see [Referring to properties](https://www.ibm.com/docs/en/devops-deploy/8.1.0?topic=deployment-properties).
 
 ### Deploying new load modules and performing a NEWCOPY on the related programs
 
@@ -60,7 +60,7 @@ Diagram showing a process with Copy Artifacts,Deploy Data Sets, and New copy res
 
 #### Component and component version for a CICS application
 
-Components represent deployable items and the processes, properties, and other configuration that operate on them. For additional information, see [Components](https://www.ibm.com/support/knowledgecenter/SS4GSP_7.2.0/com.ibm.udeploy.doc/topics/comp_ch.html) in the product documentation.
+Components represent deployable items and the processes, properties, and other configuration that operate on them. For additional information, see [Components](https://www.ibm.com/docs/en/devops-deploy/8.1.0?topic=deployment-components) in the product documentation.
 
 Create a Component to store your CICS application ready for deployment. The component name should match the CICS application name. For example: `com.ibm.cics.minibank.application`
 


### PR DESCRIPTION
I hope it's ok to submit a PR to update these links to the latest version. I've also made a minor update to the mini TOC in troubleshooting.

Thanks.